### PR TITLE
feat: get an element image by providing a selector

### DIFF
--- a/cypress/integration/element-image.js
+++ b/cypress/integration/element-image.js
@@ -1,0 +1,37 @@
+// @ts-check
+it('element image', () => {
+  cy.visit('/')
+  cy.get('[data-cy=add-todo]')
+    .type('Learn Cypress{enter}')
+    .type('Write tests{enter}')
+  cy.get('[data-cy=todo]').should('have.length', 2)
+  // get an image of the todos element
+  cy.get('.todos').cyclope('todos.png', {
+    elementSelector: '.todos',
+  })
+})
+
+it('element image with stats', () => {
+  cy.visit('/')
+  cy.get('[data-cy=add-todo]')
+    .type('Learn Cypress{enter}')
+    .type('Write tests{enter}')
+  cy.get('[data-cy=todo]').should('have.length', 2)
+  // get an image of the todos element
+  cy.get('.stat').cyclope('stat.png', {
+    elementSelector: '.stat',
+  })
+})
+
+it('element image with todos and stats', () => {
+  cy.visit('/')
+  cy.get('[data-cy=add-todo]')
+    .type('Learn Cypress{enter}')
+    .type('Write tests{enter}')
+  cy.get('[data-cy=todo]').should('have.length', 2)
+  // get an image of the todos and the stats below
+  // https://github.com/bahmutov/cyclope/issues/43
+  cy.get('.todos, .stat').cyclope('todos-and-stats.png', {
+    elementSelector: '.todos, .stat',
+  })
+})

--- a/cypress/integration/upload.js
+++ b/cypress/integration/upload.js
@@ -21,4 +21,7 @@ it('upload zip to image', () => {
   cy.get('#theme-switcher').click()
   cy.get('body').should('have.class', 'light')
   cy.clope('light-checkbox.png')
+
+  // get an image of the todos and the stats below
+  // cy.get('.todos').cyclope('todos-and-stats.png')
 })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,11 @@ declare namespace Cypress {
     removeIframes?: boolean
   }
 
+  interface ImageOptions extends SavePageOptions {
+    /** CSS selector to limit the screenshot to */
+    elementSelector?: string
+  }
+
   interface Chainable {
     /**
      * Creates an accurate image from the current page using
@@ -23,10 +28,7 @@ declare namespace Cypress {
      * @param outputImageFilename string Output PNG filename to save
      * @alias cyclope
      */
-    clope(
-      outputImageFilename: string,
-      options?: SavePageOptions,
-    ): Chainable<void>
+    clope(outputImageFilename: string, options?: ImageOptions): Chainable<void>
     /**
      * Creates an accurate image from the current page using
      * an external Cyclope image service
@@ -35,7 +37,7 @@ declare namespace Cypress {
      */
     cyclope(
       outputImageFilename: string,
-      options?: SavePageOptions,
+      options?: ImageOptions,
     ): Chainable<void>
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -329,6 +329,7 @@ function cyclope(outputImageFilename, commandOptions = {}) {
     return cy
       .task('upload', {
         ...options,
+        elementSelector: commandOptions.elementSelector,
         outputFilename: outputImageFilename,
       })
       .then(() => {


### PR DESCRIPTION
- closes #42 

```js
// get an image of the todos element
cy.get('.todos').cyclope('todos.png', {
  elementSelector: '.todos',
})
```