### PR TITLE
Do not require Cyclope service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
 
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
+      # https://github.com/cypress-io/github-action
       - name: Cypress tests 🧪
         uses: cypress-io/github-action@v2
         with:
@@ -18,6 +19,15 @@ jobs:
         env:
           CYCLOPE_SERVICE_URL: ${{ secrets.CYCLOPE_SERVICE_URL }}
           CYCLOPE_SERVICE_KEY: ${{ secrets.CYCLOPE_SERVICE_KEY }}
+
+      - name: Can skip using Cyclope service 🧪
+        uses: cypress-io/github-action@v2
+        with:
+          # we have already installed all dependencies above
+          install: false
+          start: npm start
+          wait-on: 'http://localhost:3777'
+          spec: 'cypress/integration/element-image.js'
 
       # https://github.com/actions/upload-artifact
       - uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ cy.get('#theme-switcher').realHover()
 cy.clope()
 ```
 
+If you want to simply skip DOM upload and image generation if the Cyclope service is not configured, set the Cypress environment option, for example using the `cypress.json` file
+
+```json
+{
+  "env": {
+    "cyclope": {
+      "skipUploadWithoutUrl": true
+    }
+  }
+}
+```
+
 ## Examples
 
 - [todo-app-for-cyclope](https://github.com/bahmutov/todo-app-for-cyclope)

--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,10 @@
   "baseUrl": "http://localhost:3777",
   "viewportWidth": 500,
   "experimentalSessionSupport": true,
-  "ignoreTestFiles": ["utils.js", "*.html"]
+  "ignoreTestFiles": ["utils.js", "*.html"],
+  "env": {
+    "cyclope": {
+      "skipUploadWithoutUrl": true
+    }
+  }
 }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -6,7 +6,7 @@ const fs = require('fs')
 const got = require('got')
 const del = require('del')
 const { zipFolder } = require('./zip')
-const { upload } = require('./upload')
+const { configureUpload } = require('./upload')
 
 const pipeline = promisify(stream.pipeline)
 
@@ -43,6 +43,10 @@ function printFailedTestMessage(info) {
 }
 
 function initCyclope(on, config) {
+  const cypressEnv = config.env || {}
+  const pluginOptions = cypressEnv.cyclope || {}
+  const upload = configureUpload(pluginOptions)
+
   on('task', {
     makeFolder,
     saveResource,

--- a/plugin/upload.js
+++ b/plugin/upload.js
@@ -3,63 +3,73 @@ const fs = require('fs')
 const got = require('got')
 const { URLSearchParams } = require('url')
 
-async function upload(options = {}) {
-  const uploadUrl = process.env.CYCLOPE_SERVICE_URL
-  if (!uploadUrl) {
-    throw new Error('CYCLOPE_SERVICE_URL is not set')
-  }
+function configureUpload(pluginOptions) {
+  async function upload(options = {}) {
+    const uploadUrl = process.env.CYCLOPE_SERVICE_URL
+    const key = process.env.CYCLOPE_SERVICE_KEY
+    if (!uploadUrl || !key) {
+      if (pluginOptions.skipUploadWithoutUrl) {
+        console.warn('Skipping upload without Cyclope')
+        return null
+      }
+    }
 
-  const key = process.env.CYCLOPE_SERVICE_KEY
-  if (!key) {
-    throw new Error('CYCLOPE_SERVICE_KEY is not set')
-  }
+    if (!uploadUrl) {
+      throw new Error('CYCLOPE_SERVICE_URL is not set')
+    }
+    if (!key) {
+      throw new Error('CYCLOPE_SERVICE_KEY is not set')
+    }
 
-  const { filename, outputFilename } = options
-  if (!filename) {
-    throw new Error('filename is not set')
-  }
-  if (!filename.endsWith('.zip')) {
-    throw new Error('filename must end with .zip')
-  }
-  if (!outputFilename) {
-    throw new Error('outputFilename is not set')
-  }
-  if (!outputFilename.endsWith('.png')) {
-    throw new Error('outputFilename must end with .png')
-  }
+    const { filename, outputFilename } = options
+    if (!filename) {
+      throw new Error('filename is not set')
+    }
+    if (!filename.endsWith('.zip')) {
+      throw new Error('filename must end with .zip')
+    }
+    if (!outputFilename) {
+      throw new Error('outputFilename is not set')
+    }
+    if (!outputFilename.endsWith('.png')) {
+      throw new Error('outputFilename must end with .png')
+    }
 
-  // remove filename from the options object
-  // add the key to the options object
-  const sendOptions = {
-    ...options,
-    key,
-  }
-  // @ts-ignore
-  delete sendOptions.filename
-  // @ts-ignore
-  delete sendOptions.outputFilename
-  // @ts-ignore
-  if (!sendOptions.hoverSelector) {
+    // remove filename from the options object
+    // add the key to the options object
+    const sendOptions = {
+      ...options,
+      key,
+    }
     // @ts-ignore
-    delete sendOptions.hoverSelector
+    delete sendOptions.filename
+    // @ts-ignore
+    delete sendOptions.outputFilename
+    // @ts-ignore
+    if (!sendOptions.hoverSelector) {
+      // @ts-ignore
+      delete sendOptions.hoverSelector
+    }
+
+    const search = new URLSearchParams(sendOptions)
+
+    const url = `${uploadUrl}?${search.toString()}`
+
+    const buffer = fs.readFileSync(filename)
+    const postOptions = {
+      body: buffer,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+      },
+    }
+    // @ts-ignore
+    const response = await got.post(url, postOptions)
+    // console.log('response is a buffer?', Buffer.isBuffer(response.rawBody))
+    fs.writeFileSync(outputFilename, response.rawBody)
+    return outputFilename
   }
 
-  const search = new URLSearchParams(sendOptions)
-
-  const url = `${uploadUrl}?${search.toString()}`
-
-  const buffer = fs.readFileSync(filename)
-  const postOptions = {
-    body: buffer,
-    headers: {
-      'Content-Type': 'application/octet-stream',
-    },
-  }
-  // @ts-ignore
-  const response = await got.post(url, postOptions)
-  // console.log('response is a buffer?', Buffer.isBuffer(response.rawBody))
-  fs.writeFileSync(outputFilename, response.rawBody)
-  return outputFilename
+  return upload
 }
 
-module.exports = { upload }
+module.exports = { configureUpload }

--- a/src/index.js
+++ b/src/index.js
@@ -318,6 +318,10 @@ function savePage(outputFolderOrZipFile, options = {}) {
     .then(logTiming)
 }
 
+function getPluginOptions() {
+  return Cypress._.get(Cypress.env(), 'cyclope', {})
+}
+
 function cyclope(outputImageFilename, commandOptions = {}) {
   expect(outputImageFilename)
     .to.be.a('string')


### PR DESCRIPTION
- closes #46 
If you want to simply skip DOM upload and image generation if the Cyclope service is not configured, set the Cypress environment option, for example using the `cypress.json` file

```json
{
  "env": {
    "cyclope": {
      "skipUploadWithoutUrl": true
    }
  }
}
```