### PR TITLE
Fix DOM manipulation errors in _replaceStyle function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyclope",
-  "version": "0.0.0-development",
+  "version": "0.0.1-development",
   "description": "Cypress DOM snapshots and consistent image diffing in the cloud",
   "main": "src",
   "types": "src",

--- a/src/index.js
+++ b/src/index.js
@@ -73,8 +73,13 @@ function _styleTag(style) {
 function _replaceStyle($head, existingStyle, style) {
   const styleTag = _styleTag(style)
 
-  if (existingStyle) {
-    Cypress.$(existingStyle).replaceWith(styleTag)
+  if (existingStyle && existingStyle.parentNode) {
+    try {
+      Cypress.$(existingStyle).replaceWith(styleTag)
+    } catch (e) {
+      console.warn('Failed to replace style, appending instead:', e.message)
+      $head.append(styleTag)
+    }
   } else {
     // no existing style at this index, so no more styles at all in
     // the head, so just append it


### PR DESCRIPTION
Fixes DOM manipulation crashes that occur during page saving

**Issue Fixed:**
- Sometimes it throws `DOMException: Node.insertBefore: Child to insert before is not a child of this node` error during `savePage` 

**Root Cause:**
The _replaceStyle function was attempting to replace DOM elements that may no longer exist in the DOM or have been removed by previous operations.

**Solution:**
- Added DOM existence check (`existingStyle.parentNode`) before attempting replacement
- Added try-catch block around `replaceWith()` call for graceful error handling
- Added fallback to `append()` when replacement fails
- Added warning message for debugging purposes